### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
   <url>http://maven.apache.org</url>
   <properties>
     <tomcat.version>8.5.23</tomcat.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Try a newer maven version to fix the following compilation failures:

[ERROR] Source option 5 is no longer supported. Use 6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.